### PR TITLE
fix: hide hillshade layer on base style as default

### DIFF
--- a/.changeset/selfish-kiwis-warn.md
+++ b/.changeset/selfish-kiwis-warn.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": patch
+---
+
+fix: hide hillshade layer from base style as default

--- a/assets/layers/hillshade.yml
+++ b/assets/layers/hillshade.yml
@@ -1,6 +1,8 @@
 id: hillshade
 type: hillshade
 source: terrarium
+layout:
+  visibility: none
 paint:
   hillshade-shadow-color: hsl(39, 21%, 33%)
   hillshade-illumination-direction: 315


### PR DESCRIPTION
to fix part of this issue (https://github.com/UNDP-Data/geohub/issues/2369) to hide hillshade layer as default