### PR TITLE
fix: switched unpkg.com to jsdelivr for sprite CDN

### DIFF
--- a/.changeset/pretty-suns-bow.md
+++ b/.changeset/pretty-suns-bow.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": patch
+---
+
+fix: switched unpkg.com to jsdelivr for sprite CDN

--- a/assets/aerialstyle.yml
+++ b/assets/aerialstyle.yml
@@ -33,7 +33,7 @@ sources:
       - -90
       - 180
       - 90
-sprite: https://unpkg.com/@undp-data/style@1.2.0/dist/sprite/sprite
+sprite: https://cdn.jsdelivr.net/npm/@undp-data/style@1.2.0/dist/sprite/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/bingaerial.yml

--- a/assets/style.yml
+++ b/assets/style.yml
@@ -19,7 +19,7 @@ sources:
       - -90
       - 180
       - 90
-sprite: https://unpkg.com/@undp-data/style@1.2.0/dist/sprite/sprite
+sprite: https://cdn.jsdelivr.net/npm/@undp-data/style@1.2.0/dist/sprite/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/background.yml


### PR DESCRIPTION
unpkg.com CDN is not down today. I did a little bit research, found jsdelivr looks like more reliable than unpkg.com (more users and libraries). Let me switch unpkg.com to jsdelivr

https://github.com/UNDP-Data/geohub/issues/3289

