### PR TITLE
fix: added paths of style files and sprite files to exports in package.json

### DIFF
--- a/.changeset/ninety-dancers-whisper.md
+++ b/.changeset/ninety-dancers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": patch
+---
+
+fix: added paths of style files and sprite files to exports in package.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,60 @@
     "README.md",
     "LICENSE"
   ],
+  "exports": {
+		"./dist/style.json": {
+			"import": "./dist/style.json",
+			"require": "./dist/style.json"
+		},
+    "./dist/aerialstyle.json": {
+			"import": "./dist/aerialstyle.json",
+			"require": "./dist/aerialstyle.json"
+		},
+    "./dist/sprite/sprite.json": {
+			"import": "./dist/sprite/sprite.json",
+			"require": "./dist/sprite/sprite.json"
+		},
+    "./dist/sprite/sprite.png": {
+			"import": "./dist/sprite/sprite.png",
+			"require": "./dist/sprite/sprite.png"
+		},
+    "./dist/sprite/sprite@2x.json": {
+			"import": "./dist/sprite/sprite@2x.json",
+			"require": "./dist/sprite/sprite@2x.json"
+		},
+    "./dist/sprite/sprite@2x.png": {
+			"import": "./dist/sprite/sprite@2x.png",
+			"require": "./dist/sprite/sprite@2x.png"
+		},
+    "./dist/sprite/sprite@4x.json": {
+			"import": "./dist/sprite/sprite@4x.json",
+			"require": "./dist/sprite/sprite@4x.json"
+		},
+    "./dist/sprite/sprite@4x.png": {
+			"import": "./dist/sprite/sprite@4x.png",
+			"require": "./dist/sprite/sprite@4x.png"
+		},
+    "./dist/sprite-non-sdf/sprite.png": {
+			"import": "./dist/sprite-non-sdf/sprite.png",
+			"require": "./dist/sprite-non-sdf/sprite.png"
+		},
+    "./dist/sprite-non-sdf/sprite@2x.json": {
+			"import": "./dist/sprite-non-sdf/sprite@2x.json",
+			"require": "./dist/sprite-non-sdf/sprite@2x.json"
+		},
+    "./dist/sprite-non-sdf/sprite@2x.png": {
+			"import": "./dist/sprite-non-sdf/sprite@2x.png",
+			"require": "./dist/sprite-non-sdf/sprite@2x.png"
+		},
+    "./dist/sprite-non-sdf/sprite@4x.json": {
+			"import": "./dist/sprite-non-sdf/sprite@4x.json",
+			"require": "./dist/sprite-non-sdf/sprite@4x.json"
+		},
+    "./dist/sprite-non-sdf/sprite@4x.png": {
+			"import": "./dist/sprite-non-sdf/sprite@4x.png",
+			"require": "./dist/sprite-non-sdf/sprite@4x.png"
+		}
+	},
   "scripts": {
     "release": "changeset publish"
   },


### PR DESCRIPTION
I would like to use NPM package to directly import style file in geohub, so I added their paths in exports of package.json.