### PR TITLE
fix: BREAKING CHANGE. Change sprite path from CDN to relative path

### DIFF
--- a/.changeset/nervous-beers-bathe.md
+++ b/.changeset/nervous-beers-bathe.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": major
+---
+
+fix: BREAKING CHANGE. Change sprite path from CDN to relative path

--- a/assets/aerialstyle.yml
+++ b/assets/aerialstyle.yml
@@ -33,7 +33,7 @@ sources:
       - -90
       - 180
       - 90
-sprite: https://unpkg.com/@undp-data/style@1.2.0/dist/sprite/sprite
+sprite: ./sprite/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/bingaerial.yml

--- a/assets/style.yml
+++ b/assets/style.yml
@@ -19,7 +19,7 @@ sources:
       - -90
       - 180
       - 90
-sprite: https://unpkg.com/@undp-data/style@1.2.0/dist/sprite/sprite
+sprite: ./sprite/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/background.yml


### PR DESCRIPTION
I realized relative path can work for sprite because it is hosted in the save folder. But I will increase a major version since this might cause any issues (particularly the code to load sprite file in geohub).