### PR TITLE
fix: fixed the position of waterway-label layer in positron to be the same order with other styles

### DIFF
--- a/.changeset/clever-books-begin.md
+++ b/.changeset/clever-books-begin.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": patch
+---
+
+fix: fixed the position of waterway-label layer in positron to be the same order with other styles

--- a/assets/positron.yml
+++ b/assets/positron.yml
@@ -36,7 +36,6 @@ layers:
   - !!inc/file positron/water_shadow.yml
   - !!inc/file positron/aeroway-runway.yml
   - !!inc/file positron/aeroway-taxiway.yml
-  - !!inc/file positron/waterway_label.yml
   - !!inc/file positron/tunnel_service_case.yml
   - !!inc/file positron/tunnel_minor_case.yml
   - !!inc/file positron/tunnel_sec_case.yml
@@ -90,6 +89,7 @@ layers:
   - !!inc/file positron/building-top.yml
   - !!inc/file positron/boundary_country_outline.yml
   - !!inc/file positron/boundary_country_inner.yml
+  - !!inc/file positron/waterway_label.yml
   - !!inc/file positron/watername_ocean.yml
   - !!inc/file positron/watername_sea.yml
   - !!inc/file positron/watername_lake.yml


### PR DESCRIPTION
I found there is a bug of waterway-label position in positron style.