### PR TITLE
fix: use correct un-esri sprite url

### DIFF
--- a/.changeset/poor-candies-hammer.md
+++ b/.changeset/poor-candies-hammer.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": patch
+---
+
+fix: supply correct un-esri sprite url

--- a/assets/aerialstyle.yml
+++ b/assets/aerialstyle.yml
@@ -44,7 +44,7 @@ sprite:
   - id: undp
     url: ./sprite/sprite
   - id: default
-    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite_S
+    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/bingaerial.yml

--- a/assets/dark.yml
+++ b/assets/dark.yml
@@ -29,7 +29,7 @@ sprite:
   - id: undp
     url: ./sprite/sprite
   - id: default
-    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite_S
+    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file dark/background.yml

--- a/assets/positron.yml
+++ b/assets/positron.yml
@@ -30,7 +30,7 @@ sprite:
   - id: undp
     url: ./sprite/sprite
   - id: default
-    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite_S
+    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file positron/background.yml

--- a/assets/style.yml
+++ b/assets/style.yml
@@ -30,7 +30,7 @@ sprite:
   - id: undp
     url: ./sprite/sprite
   - id: default
-    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite_S
+    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/background.yml

--- a/assets/un_street_map.yml
+++ b/assets/un_street_map.yml
@@ -5,7 +5,7 @@ sprite:
   - id: undp
     url: ./sprite/sprite
   - id: default
-    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite_S
+    url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 sources:
   esri:


### PR DESCRIPTION
In this PR


1. Changes ESRI Sprite URL from https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite_S

to 

https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite