### PR TITLE
fix: switched the default sprite source

### DIFF
--- a/assets/aerialstyle.yml
+++ b/assets/aerialstyle.yml
@@ -41,9 +41,9 @@ sources:
       - 180
       - 90
 sprite:
-  - id: undp
-    url: ./sprite/sprite
   - id: default
+    url: ./sprite/sprite
+  - id: esri
     url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:

--- a/assets/dark.yml
+++ b/assets/dark.yml
@@ -26,9 +26,9 @@ sources:
       - 180
       - 90
 sprite:
-  - id: undp
-    url: ./sprite/sprite
   - id: default
+    url: ./sprite/sprite
+  - id: esri
     url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:

--- a/assets/positron.yml
+++ b/assets/positron.yml
@@ -27,9 +27,9 @@ sources:
       - 180
       - 90
 sprite:
-  - id: undp
-    url: ./sprite/sprite
   - id: default
+    url: ./sprite/sprite
+  - id: esri
     url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:

--- a/assets/style.yml
+++ b/assets/style.yml
@@ -27,9 +27,9 @@ sources:
       - 180
       - 90
 sprite:
-  - id: undp
-    url: ./sprite/sprite
   - id: default
+    url: ./sprite/sprite
+  - id: esri
     url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:

--- a/assets/un_street_map.yml
+++ b/assets/un_street_map.yml
@@ -2,9 +2,9 @@ version: 8
 name: UN Street Map
 metadata: {}
 sprite:
-  - id: undp
-    url: ./sprite/sprite
   - id: default
+    url: ./sprite/sprite
+  - id: esri
     url: https://pro-ags2.dfs.un.org/arcgis/rest/services/Hosted/Unite_StreetMapVT_CVW_V01/VectorTileServer/resources/sprites/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 sources:


### PR DESCRIPTION
In this PR

1. [x] Switched the default sprite source to UNDP source
2. [ ] Changed icon-image source for ESRI sources from `<icon_image>` to `esri:<icon_image>`