### PR TITLE
fix: added terrarium-hillshade only for hillshade layer since maplibre complains if both hillshade and terrain use the same raster-dem source.

### DIFF
--- a/.changeset/public-news-invent.md
+++ b/.changeset/public-news-invent.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/style": patch
+---
+
+fix: added terrarium-hillshade only for hillshade layer since maplibre complains if both hillshade and terrain use the same raster-dem source.

--- a/assets/aerialstyle.yml
+++ b/assets/aerialstyle.yml
@@ -40,6 +40,20 @@ sources:
       - -90
       - 180
       - 90
+  terrarium-hillshade:
+    type: raster-dem
+    attribution: '&copy; <a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener">Tilezen Joerd</a>'
+    tiles:
+      - https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+    minzoom: 0
+    maxzoom: 15
+    tileSize: 256
+    encoding: terrarium
+    bounds:
+      - -180
+      - -90
+      - 180
+      - 90
 sprite:
   - id: default
     url: ./sprite/sprite

--- a/assets/blank.yml
+++ b/assets/blank.yml
@@ -16,6 +16,20 @@ sources:
       - -90
       - 180
       - 90
+  terrarium-hillshade:
+    type: raster-dem
+    attribution: '&copy; <a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener">Tilezen Joerd</a>'
+    tiles:
+      - https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+    minzoom: 0
+    maxzoom: 15
+    tileSize: 256
+    encoding: terrarium
+    bounds:
+      - -180
+      - -90
+      - 180
+      - 90
 sprite: ./sprite/sprite
 glyphs: https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf
 layers:

--- a/assets/dark.yml
+++ b/assets/dark.yml
@@ -25,6 +25,20 @@ sources:
       - -90
       - 180
       - 90
+  terrarium-hillshade:
+    type: raster-dem
+    attribution: '&copy; <a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener">Tilezen Joerd</a>'
+    tiles:
+      - https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+    minzoom: 0
+    maxzoom: 15
+    tileSize: 256
+    encoding: terrarium
+    bounds:
+      - -180
+      - -90
+      - 180
+      - 90
 sprite:
   - id: default
     url: ./sprite/sprite

--- a/assets/layers/hillshade.yml
+++ b/assets/layers/hillshade.yml
@@ -1,6 +1,6 @@
 id: hillshade
 type: hillshade
-source: terrarium
+source: terrarium-hillshade
 layout:
   visibility: none
 paint:

--- a/assets/positron.yml
+++ b/assets/positron.yml
@@ -26,6 +26,20 @@ sources:
       - -90
       - 180
       - 90
+  terrarium-hillshade:
+    type: raster-dem
+    attribution: '&copy; <a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener">Tilezen Joerd</a>'
+    tiles:
+      - https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+    minzoom: 0
+    maxzoom: 15
+    tileSize: 256
+    encoding: terrarium
+    bounds:
+      - -180
+      - -90
+      - 180
+      - 90
 sprite:
   - id: default
     url: ./sprite/sprite

--- a/assets/style.yml
+++ b/assets/style.yml
@@ -26,6 +26,20 @@ sources:
       - -90
       - 180
       - 90
+  terrarium-hillshade:
+    type: raster-dem
+    attribution: '&copy; <a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener">Tilezen Joerd</a>'
+    tiles:
+      - https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+    minzoom: 0
+    maxzoom: 15
+    tileSize: 256
+    encoding: terrarium
+    bounds:
+      - -180
+      - -90
+      - 180
+      - 90
 sprite:
   - id: default
     url: ./sprite/sprite

--- a/assets/un_street_map.yml
+++ b/assets/un_street_map.yml
@@ -29,6 +29,20 @@ sources:
       - -90
       - 180
       - 90
+  terrarium-hillshade:
+    type: raster-dem
+    attribution: '&copy; <a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener">Tilezen Joerd</a>'
+    tiles:
+      - https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+    minzoom: 0
+    maxzoom: 15
+    tileSize: 256
+    encoding: terrarium
+    bounds:
+      - -180
+      - -90
+      - 180
+      - 90
 layers:
   - !!inc/file layers/hillshade.yml
   - !!inc/file un_street_map/Landuse/LND_Landcover_S/Forest.yml


### PR DESCRIPTION
I copied `terrarium` raster-dem source to created new raster-dem source `terrarium-hillshade` only for hillshade layer.

This PR can fix an issue of maplibre raised by this draft P (https://github.com/UNDP-Data/geohub/pull/5081) in GeoHub.

When both hillshade and terrain are enabled, maplibre gives a warning saying that "You are using the same source for a hillshade layer and for 3D terrain. Please consider using two separate sources to improve rendering quality."

So, `terrarium` source will only be used by 3D terrain with TerrainControl, and `terrarium-hillshade` will be used only for hillshade layer.